### PR TITLE
Correction for importing _switches.scss

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -29,7 +29,7 @@
 //   "foundation/components/side-nav",
 //   "foundation/components/split-buttons",
 //   "foundation/components/sub-nav",
-//   "foundation/components/switch",
+//   "foundation/components/switches",
 //   "foundation/components/tables",
 //   "foundation/components/tabs",
 //   "foundation/components/thumbs",


### PR DESCRIPTION
The file is named `_swicthes.scss` not `_switch.scss`

https://github.com/zurb/foundation/blob/v5.4.3/scss%2Ffoundation%2Fcomponents%2F_switches.scss
