### PR TITLE
Fixes misspelled component name.

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -29,7 +29,7 @@
 //   "foundation/components/side-nav",
 //   "foundation/components/split-buttons",
 //   "foundation/components/sub-nav",
-//   "foundation/components/switch",
+//   "foundation/components/switches",
 //   "foundation/components/tables",
 //   "foundation/components/tabs",
 //   "foundation/components/thumbs",


### PR DESCRIPTION
Fixed this tiny bug in one of my Foundation-based projects today, thought I'd share. Thanks!
