### PR TITLE
detect sass 3.4 or newer properly

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -24,7 +24,7 @@ javascripts_dir = "js"
 # and then run:
 # sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass
 
-if Gem.loaded_specs["sass"].version > Gem::Version.create('3.3')
+if Gem.loaded_specs["sass"].version >= Gem::Version.create('3.4')
   warn "You're using Sass 3.4 or higher to compile Foundation. This version causes CSS classes to output incorrectly, so we recommend using Sass 3.3 or 3.2."
   warn "To use the right version of Sass on this project, run \"bundle\" and then use \"bundle exec compass watch\" to compile Foundation."
 end


### PR DESCRIPTION
This fixes sass version detection to properly detect sass 3.4. I was getting the warning about 3.4 with sass 3.3.14.
