### PR TITLE
Sass 3.4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "sass", "~> 3.3.0"
+gem "sass", "~> 3.4.0"
 gem "compass", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.3.1)
+    chunky_png (1.3.3)
     compass (1.0.1)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.1)
@@ -14,16 +14,16 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    ffi (1.9.5)
+    ffi (1.9.6)
     multi_json (1.10.1)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    sass (3.3.14)
+    sass (3.4.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   compass (~> 1.0)
-  sass (~> 3.3.0)
+  sass (~> 3.4.0)


### PR DESCRIPTION
Foundation 5.5 will introduce the `!global` keyword into the codebase, adding Sass 3.4 support. This should be merged after Foundation 5.5 has been published.
